### PR TITLE
Wrap built comments into an array

### DIFF
--- a/doc/tutorial8.md
+++ b/doc/tutorial8.md
@@ -77,8 +77,8 @@ Next, we modify the `comment-list` component:
 (defn comment-list [{:keys [comments]}]
   (om/component
    (dom/div #js {:className "commentList"}
-            (om/build-all comment comments
-                          {:key :id}))))
+            (into-array (om/build-all comment comments
+                                      {:key :id})))))
 ```
 
 We specify a way in the options map to distinguish these comments from


### PR DESCRIPTION
On tutorial8.md, the final code for the comment-list has lost the <code>into-array</code> from previously in the tutorial. A call to <code>prn</code> with the results seems to show that, without that,  just a standard list of objects is being returned, and an id is all that gets rendered. Once I added <code>into-array</code> back in, the comments rendered correctly.
